### PR TITLE
fix test branch selection on OSX

### DIFF
--- a/bin/jenkinsRun.sh
+++ b/bin/jenkinsRun.sh
@@ -60,7 +60,7 @@ function jobStatus()
 
 function noColor()
 {
-  echo -E $1 | sed -r "s/\x1B\[(([0-9]{1,2})?(;)?([0-9]{1,2})?)?[m,K,H,f,J]//g"
+  echo -E $1 | sed -E "s/\x1B\[(([0-9]{1,2})?(;)?([0-9]{1,2})?)?[m,K,H,f,J]//g"
 }
 
 function chooseBranch()


### PR DESCRIPTION
- change 'SED' usage to comply with possix standard
- since macos is packed with some legacy SED impl