### PR TITLE
fix: re-scan for re-opened branch

### DIFF
--- a/bin/jenkinsOp.sh
+++ b/bin/jenkinsOp.sh
@@ -102,7 +102,7 @@ triggerBuild()
   RESPONSE=$( requestBuild ${JOB_URL} )
   echo -e "[ $( statusColor ${RESPONSE} ) ] @ $JOB_URL"
   
-  if [ "$RESPONSE" == 404 ] ; then
+  if [ "$RESPONSE" == 404 ] || [ "$RESPONSE" == 409 ] ; then
       # job may requires a manual rescan to expose our new branch | isolate in sub bash to avoid conflicts!
       SCANNED=$( rescanBranches "https://$JENKINS/job/$RUN_JOB/" 3>&1 1>&2 2>&3 )
       # re-try


### PR DESCRIPTION
if branch is already archived (due to previous PR close) ... jenkins returns a 409, let's reactive it to with a re-scan.